### PR TITLE
Refactor Tracker and TrackerBuilder for device info

### DIFF
--- a/Shortha.Domain/Tracker.cs
+++ b/Shortha.Domain/Tracker.cs
@@ -2,19 +2,23 @@
 
 public class Tracker
 {
-    public string?BrowserName { get; set; }
-    public string?BrowserVersion { get; set; }
-    public string?OsName { get; set; }
-    public string?DeviceBrand { get; set; }
-    public string?DeviceType { get; set; }
-    public string?UserAgent { get; set; }
+    public string? BrowserName { get; set; }
+    public string? BrowserVersion { get; set; }
+    public string? OsName { get; set; }
+
+    public string? Brand { get; set; }
+    public string? Model { get; set; }
+    public string? Device { get; set; }
+
+    public string? UserAgent { get; set; }
+    public string? UserId { get; set; }
 
     private string? _ipAddress;
     public bool IsBot { get; set; } = false;
     public string TimeZone { get; set; } = "Unknown";
-    public string Country { get; set; }
-    public string Region { get; set; }
-    public string City { get; set; }
+    public string Country { get; set; } = "Unknown";
+    public string Region { get; set; } = "Unknown";
+    public string City { get; set; } = "Unknown";
 
     public string IpAddress
     {


### PR DESCRIPTION
Updated Tracker model to use Brand, Model, and Device properties instead of DeviceBrand and DeviceType. Refactored TrackerBuilder to simplify device detection and IP handling, removing dependency on IPinfoClient from its constructor. Enhanced TrackerFilter to log user agent and IP information, and updated its usage of TrackerBuilder to match the new API.